### PR TITLE
Separating JoinMessage en Broadcast enable bool

### DIFF
--- a/Common-Utils/EventHandlers.cs
+++ b/Common-Utils/EventHandlers.cs
@@ -31,6 +31,7 @@ namespace Common_Utils
         public CustomInventory Inventories;
 
         public bool EnableBroadcasting;
+        public bool EnableJoinmessage;
         public bool EnableAutoNuke;
         public bool Enable914;
         public bool EnableInventories;
@@ -44,7 +45,7 @@ namespace Common_Utils
         public bool ClearItems;
 
         // T H I C K constructor
-        public EventHandlers(bool uh, Dictionary<Scp914PlayerUpgrade, Scp914Knob> roles, Dictionary<Scp914ItemUpgrade, Scp914Knob> items, Dictionary<RoleType, int> health, string bm, string jm, int bt, int bs, int jt, CustomInventory inven, int nukeTime, bool autoNuke, bool enable914, bool enableBroadcasting, bool enableInventories, bool clearRag, float clearInt, bool clearItems, bool clearOnlyPocket = false)
+        public EventHandlers(bool uh, Dictionary<Scp914PlayerUpgrade, Scp914Knob> roles, Dictionary<Scp914ItemUpgrade, Scp914Knob> items, Dictionary<RoleType, int> health, string bm, string jm, int bt, int bs, int jt, CustomInventory inven, int nukeTime, bool autoNuke, bool enable914, bool enableJoinmessage, bool enableBroadcasting, bool enableInventories, bool clearRag, float clearInt, bool clearItems, bool clearOnlyPocket = false)
         {
             Roles = roles;
             Items = items;
@@ -57,6 +58,7 @@ namespace Common_Utils
             Inventories = inven;
             UpgradeHand = uh;
             ANTime = nukeTime;
+            EnableJoinmessage = enableJoinmessage;
             EnableBroadcasting = enableBroadcasting;
             EnableAutoNuke = autoNuke;
             Enable914 = enable914;
@@ -166,7 +168,7 @@ namespace Common_Utils
 
         internal void PlayerJoin(PlayerJoinEvent ev)
         {
-            if (!EnableBroadcasting)
+            if (!EnableJoinmessage)
                 return;
 
             Extenstions.Broadcast(ev.Player, (uint)JTime, JMessage.Replace("%player%", ev.Player.nicknameSync.MyNick));

--- a/Common-Utils/Plugin.cs
+++ b/Common-Utils/Plugin.cs
@@ -229,7 +229,7 @@ namespace Common_Utils
             int boradcastSeconds = Config.GetInt("util_broadcast_seconds", 300); // 300 is 5 minutes. :D
             int boradcastTime = Config.GetInt("util_broadcast_time", 4);
 
-            bool enableJoinmessage = Config.GetBool("util_broadcast_enable", true);
+            bool enableJoinmessage = Config.GetBool("util_joinmessage_enable", true);
             string joinMessage = Config.GetString("util_joinMessage", "<color=lime>Welcome <b>%player%</b>! <i>Please read our rules!</i></color>");
             int joinMessageTime = Config.GetInt("util_joinMessage_time", 6); // 6 seconds duhhhhh
 

--- a/Common-Utils/Plugin.cs
+++ b/Common-Utils/Plugin.cs
@@ -222,13 +222,14 @@ namespace Common_Utils
 
             bool upgradeHeldItems = Config.GetBool("util_914_upgrade_hand", true);
 
-            bool enableBroadcasting = Config.GetBool("util_broadcast_enable", true);
+            bool enableBroadcasting = Config.GetBool("util_broadcast_enable", false); //nobody wants this true on default -rin
 
             string broadcastMessage = Config.GetString("util_broadcast_message", "<color=lime>This server is running <b><color=red>EXILED-CommonUtils</color></b>, enjoy playing!</color>");
 
             int boradcastSeconds = Config.GetInt("util_broadcast_seconds", 300); // 300 is 5 minutes. :D
             int boradcastTime = Config.GetInt("util_broadcast_time", 4);
 
+            bool enableJoinmessage = Config.GetBool("util_broadcast_enable", true);
             string joinMessage = Config.GetString("util_joinMessage", "<color=lime>Welcome <b>%player%</b>! <i>Please read our rules!</i></color>");
             int joinMessageTime = Config.GetInt("util_joinMessage_time", 6); // 6 seconds duhhhhh
 
@@ -240,7 +241,7 @@ namespace Common_Utils
             bool clearOnlyPocket = Config.GetBool("util_cleanup_only_pocket", false);
             bool clearItems = Config.GetBool("util_cleanup_items", true);
 
-            EventHandler = new EventHandlers(upgradeHeldItems, scp914Roles, scp914Items, roleHealth, broadcastMessage, joinMessage, boradcastTime, boradcastSeconds, joinMessageTime, Inventories, autoNukeTime, enableAutoNuke, enable914Configs, enableBroadcasting, enableCustomInv, clearRagdolls, clearRagdollTimer, clearOnlyPocket, clearItems)
+            EventHandler = new EventHandlers(upgradeHeldItems, scp914Roles, scp914Items, roleHealth, broadcastMessage, joinMessage, boradcastTime, boradcastSeconds, joinMessageTime, Inventories, autoNukeTime, enableAutoNuke, enable914Configs, enableJoinmessage, enableBroadcasting, enableCustomInv, clearRagdolls, clearRagdollTimer, clearOnlyPocket, clearItems)
             { 
                 LockAutoNuke = Config.GetBool("util_autonuke_lock", false)
             };


### PR DESCRIPTION
Adding new config option:

util_joinmessage_enable: true

so that joinmessages dont have to rely on util_broadcast_enable that spams the god damn server every fucking 5 minutes to remind EVERY player that this server is using common-utils.

Also set util_broadcast_enable: false as default.